### PR TITLE
Fix package name

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: quartz_mailer
+name: quartz-mailer
 version: 0.2.0
 
 crystal: 0.22.0


### PR DESCRIPTION
Dependency declaration in [src/amber/cli/templates/app/shard.yml.ecr](https://github.com/amberframework/amber/blob/master/src/amber/cli/templates/app/shard.yml.ecr#L31) and in [README.md](https://github.com/amberframework/quartz-mailer/blob/master/README.md) fails when pulling in dependency because of the package name.