### PR TITLE
Update kilt to 0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,7 +12,7 @@ dependencies:
 
   smtp:
     github: raydf/smtp.cr
-    branch: master
+    version: ~> 0.1
 
 development_dependencies:
   expect:

--- a/shard.yml
+++ b/shard.yml
@@ -1,14 +1,14 @@
 name: quartz_mailer
 version: 0.2.0
 
-crystal: 0.22.0
+crystal: 0.23.1
 
 license: MIT
 
 dependencies:
   kilt:
     github: jeromegn/kilt
-    version: ~> 0.3.3
+    version: ~> 0.4.0
 
   smtp:
     github: raydf/smtp.cr


### PR DESCRIPTION
This PR could be the key to solve [kilt dependency mismatch](https://github.com/amberframework/amber/pull/370#issuecomment-342789693) on Amber framework 😄 

Maybe we need to release a new `quartz-mailer` version too, like `v0.2.1`