### PR TITLE
Update dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: quartz_mailer
-version: 0.2.0
+version: 0.3.0
 
 crystal: 0.23.1
 
@@ -12,7 +12,7 @@ dependencies:
 
   smtp:
     github: raydf/smtp.cr
-    version: ~> 0.1
+    version: ~> 0.2.0
 
 development_dependencies:
   expect:

--- a/src/quartz_mailer/version.cr
+++ b/src/quartz_mailer/version.cr
@@ -1,3 +1,3 @@
 module Quartz::Mailer
-  VERSION = "0.1.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
This PR updates `quartz-mailer` dependency after fixing [this shards issue](https://github.com/crystal-lang/shards/issues/183).

`smtp.cr` issue already fixed here 👉 https://github.com/raydf/smtp.cr/issues/10

To avoid repeat dependency mismatch again this release is `v0.3.0` so old projects using `v0.2.1` will not have any problem installing shards.

After merging this we'll release `v0.3.0` for quartz-mailer 👍 