### PR TITLE
Upgrade email shard to 0.2.5

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,4 +12,4 @@ dependencies:
 
   email:
     github: arcage/crystal-email
-    version: ~> 0.2.4
+    version: ~> 0.2.5

--- a/src/quartz_mailer.cr
+++ b/src/quartz_mailer.cr
@@ -18,7 +18,6 @@ class Quartz::Mailer
       puts "SMTP Disabled, not actually sending email"
     end
 
-  # TODO this doesn't actually stop the failure from killing the server
   rescue e : EMail::Error::MessageError
     puts "Email message couldn't be delivered."
     puts e.message


### PR DESCRIPTION
The recently merged upgrade pointed to a slightly out of date crystal-email, which had an `exit` for certain types of smtp connection failures. @arcage was kind and prompt and removing that exit for us.

This simply updates the dependency to take that into account.