### PR TITLE
Allow authenticated SMTP connections to be used

### DIFF
--- a/spec/quartz/config_spec.cr
+++ b/spec/quartz/config_spec.cr
@@ -13,14 +13,55 @@ describe Quartz::Config do
       Quartz.config.smtp_address.should eq "127.0.0.1"
     end
 
-    it "defaults to port 25" do
+    it "defaults to port 1025" do
       Quartz.reset_config
+      Quartz.config.smtp_port.should eq 1025
+    end
+
+    it "defaults to tls disabled" do
+      Quartz.reset_config
+      Quartz.config.use_tls.should be_false
+    end
+
+    it "defaults to authentication disabled" do
+      Quartz.reset_config
+      Quartz.config.use_authentication.should be_false
+    end
+
+    it "allows smtp_port to be set via string" do
+      Quartz.reset_config
+      Quartz.config.smtp_port = "25"
       Quartz.config.smtp_port.should eq 25
     end
 
-    it "defaults to ssl disabled" do
+    it "allows smtp_port to be set via int32" do
       Quartz.reset_config
-      Quartz.config.use_ssl.should be_false
+      Quartz.config.smtp_port = 25_i32
+      Quartz.config.smtp_port.should eq 25
+    end
+
+    it "defaults to username=nil" do
+      Quartz.reset_config
+      Quartz.config.username?.should be_nil
+    end
+
+    it "defaults to password=nil" do
+      Quartz.reset_config
+      Quartz.config.password?.should be_nil
+    end
+
+    it "raises when username is nil and tried to be read" do
+      Quartz.reset_config
+      expect_raises Exception do
+        Quartz.config.username
+      end
+    end
+
+    it "raises when password is nil and tried to be read" do
+      Quartz.reset_config
+      expect_raises Exception do
+        Quartz.config.password
+      end
     end
   end
 
@@ -43,6 +84,8 @@ describe Quartz::Config do
       alternate_reality = "127.1.1.1"
       mailcatcher_port = 1080
       happy_logger = Logger.new nil
+      user = "me"
+      password = "secrets"
 
       Quartz.reset_config
 
@@ -52,14 +95,23 @@ describe Quartz::Config do
       Quartz.config.smtp_port = mailcatcher_port
       Quartz.config.smtp_port.should eq mailcatcher_port
 
-      Quartz.config.use_ssl = true
-      Quartz.config.use_ssl.should eq true
+      Quartz.config.use_tls = true
+      Quartz.config.use_tls.should eq true
 
       Quartz.config.smtp_enabled = true
       Quartz.config.smtp_enabled.should be_true
 
       Quartz.config.logger = happy_logger
       Quartz.config.logger.should eq happy_logger
+
+      Quartz.config.use_authentication = true
+      Quartz.config.use_authentication.should be_true
+
+      Quartz.config.username = user
+      Quartz.config.username.should eq user
+
+      Quartz.config.password = password
+      Quartz.config.password.should eq password
     end
   end
 end

--- a/src/quartz_mailer.cr
+++ b/src/quartz_mailer.cr
@@ -7,7 +7,7 @@ class Quartz::Mailer
     config = Quartz.config
 
     unless config.smtp_enabled
-      puts "SMTP Disabled, not actually sending email"
+      config.logger.warn "SMTP Disabled, not actually sending email."
       return
     end
 

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -1,13 +1,27 @@
 module Quartz
   class Config
     property smtp_address = "127.0.0.1"
-    property smtp_port = 25
-    property use_ssl = false
+    getter   smtp_port    = 1025
+
+    property! username : String?
+    property! password : String?
+
+    property use_authentication = false
+    property use_tls = false
     property smtp_enabled = false
+
     property logger : Logger
 
     def initialize
       @logger = Logger.new STDOUT
+    end
+
+    def smtp_port=(port : String)
+      @smtp_port = port.to_i32
+    end
+
+    def smtp_port=(port : Number)
+      @smtp_port = port.to_i32
     end
   end
 


### PR DESCRIPTION
In my sprint to get this upgraded, I neglected to allow configuration options for username/password authentication.

This time around, I learned something about tls and ssl being different connection mechanisms, so I've also renamed the `use_ssl` option to `use_tls`. This is a breaking change, but I don't think it will have much effect because the [generated mail config](https://github.com/amberframework/amber/blob/master/src/amber/cli/templates/mailer/config/initializers/mailer.cr.ecr) doesn't suggest that option.

- Provides `config.use_authentication`, `config.username`, and `config.password`
- Renames `use_ssl` config option to `use_tls`
- Properly uses the logger instead of just `puts`ing when SMTP is disabled.
- Allows `config.smtp_port` to be set via string, to make `config.smtp_port = ENV["SMTP_PORT"]` easy.