### PR TITLE
Added openssl_verify_mode support for tls connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.24.1
+FROM crystallang/crystal:0.26.1
 
 WORKDIR /app/user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/user
 
 ADD . /app/user
 
-RUN crystal deps
+RUN shards install
 
 ENV SMTP_URL localhost:25
 

--- a/shard.yml
+++ b/shard.yml
@@ -12,4 +12,4 @@ dependencies:
 
   email:
     github: arcage/crystal-email
-    version: ~> 0.2.5
+    version: ~> 0.3.0

--- a/spec/quartz/config_spec.cr
+++ b/spec/quartz/config_spec.cr
@@ -91,7 +91,6 @@ describe Quartz::Config do
       happy_logger = Logger.new nil
       user = "me"
       password = "secrets"
-      verification_mode = "none"
 
       Quartz.reset_config
 
@@ -104,8 +103,8 @@ describe Quartz::Config do
       Quartz.config.use_tls = true
       Quartz.config.use_tls.should eq true
 
-      Quartz.config.openssl_verify_mode = verification_mode
-      Quartz.config.openssl_verify_mode.should eq "none"
+      Quartz.config.openssl_verify_mode = :none
+      Quartz.config.openssl_verify_mode.should eq OpenSSL::SSL::VerifyMode::None
 
       Quartz.config.smtp_enabled = true
       Quartz.config.smtp_enabled.should be_true

--- a/spec/quartz/config_spec.cr
+++ b/spec/quartz/config_spec.cr
@@ -23,9 +23,9 @@ describe Quartz::Config do
       Quartz.config.use_tls.should be_false
     end
 
-    it "defaults to openssl_verify_mode default" do
+    it "defaults to openssl_verify_mode default (:peer)" do
       Quartz.reset_config
-      Quartz.config.openssl_verify_mode.should be_nil
+      Quartz.config.openssl_verify_mode.should eq OpenSSL::SSL::VerifyMode::PEER
     end
 
     it "defaults to authentication disabled" do
@@ -104,7 +104,7 @@ describe Quartz::Config do
       Quartz.config.use_tls.should eq true
 
       Quartz.config.openssl_verify_mode = :none
-      Quartz.config.openssl_verify_mode.should eq OpenSSL::SSL::VerifyMode::None
+      Quartz.config.openssl_verify_mode.should eq OpenSSL::SSL::VerifyMode::NONE
 
       Quartz.config.smtp_enabled = true
       Quartz.config.smtp_enabled.should be_true

--- a/spec/quartz/config_spec.cr
+++ b/spec/quartz/config_spec.cr
@@ -23,6 +23,11 @@ describe Quartz::Config do
       Quartz.config.use_tls.should be_false
     end
 
+    it "defaults to openssl_verify_mode default" do
+      Quartz.reset_config
+      Quartz.config.openssl_verify_mode.should be_nil
+    end
+
     it "defaults to authentication disabled" do
       Quartz.reset_config
       Quartz.config.use_authentication.should be_false
@@ -86,6 +91,7 @@ describe Quartz::Config do
       happy_logger = Logger.new nil
       user = "me"
       password = "secrets"
+      verification_mode = "none"
 
       Quartz.reset_config
 
@@ -97,6 +103,9 @@ describe Quartz::Config do
 
       Quartz.config.use_tls = true
       Quartz.config.use_tls.should eq true
+
+      Quartz.config.openssl_verify_mode = verification_mode
+      Quartz.config.openssl_verify_mode.should eq "none"
 
       Quartz.config.smtp_enabled = true
       Quartz.config.smtp_enabled.should be_true

--- a/src/quartz_mailer.cr
+++ b/src/quartz_mailer.cr
@@ -18,7 +18,8 @@ class Quartz::Mailer
         config.smtp_port,
         use_tls: config.use_tls,
         logger: config.logger,
-        auth: { config.username, config.password },
+        auth: {config.username, config.password},
+        openssl_verify_mode: config.openssl_verify_mode
       )
     else
       connect_and_send(
@@ -26,10 +27,10 @@ class Quartz::Mailer
         config.smtp_address,
         config.smtp_port,
         use_tls: config.use_tls,
-        logger: config.logger
+        openssl_verify_mode: config.openssl_verify_mode,
+        logger: config.logger,
       )
     end
-
   end
 
   private def self.connect_and_send(message : Message, smtp_address : String, smtp_port : Int32, **connection_options)

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -8,7 +8,7 @@ module Quartz
 
     property use_authentication = false
     property use_tls = false
-    property openssl_verify_mode : String?
+    property openssl_verify_mode : OpenSSL::SSL::VerifyMode?
     property smtp_enabled = false
 
     property logger : Logger

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -8,7 +8,7 @@ module Quartz
 
     property use_authentication = false
     property use_tls = false
-    property openssl_verify_mode : OpenSSL::SSL::VerifyMode?
+    property openssl_verify_mode : OpenSSL::SSL::VerifyMode = :peer
     property smtp_enabled = false
 
     property logger : Logger

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -1,13 +1,14 @@
 module Quartz
   class Config
     property smtp_address = "127.0.0.1"
-    getter   smtp_port    = 1025
+    getter smtp_port = 1025
 
     property! username : String?
     property! password : String?
 
     property use_authentication = false
     property use_tls = false
+    property openssl_verify_mode : String?
     property smtp_enabled = false
 
     property logger : Logger


### PR DESCRIPTION
* Added configuration to set a openssl_verification_mode a la ActionMailer
* Setting it `none` can help you with testing `tls` connections locally or with mail-servers with self-signed certificates.

**Note:** Subjected to merge of this [PR #37](https://github.com/arcage/crystal-email/pull/37) at [arcage/crystal-email](https://github.com/arcage/crystal-email)