### PR TITLE
Add remove_*_recipient methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ To delivery a new email:
 WelcomeMailer.new(name, email).deliver
 ```
 
+To remove a recipient:
+```crystal
+remove_to_recipient email: "to@foobar.com"
+remove_cc_recipient email: "cc@foobar.com"
+remove_bcc_recipient email: "bcc@foobar.com"
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/amber-crystal/quartz-mailer/fork )

--- a/spec/quartz/message_spec.cr
+++ b/spec/quartz/message_spec.cr
@@ -55,6 +55,7 @@ describe Quartz::Message do
   context "destination" do
     {% for destination in ["to", "cc", "bcc"] %}
       {% destination = destination.id %}
+
       it "{{ destination }} allows setting destinations without name" do
         message = build
         message.{{ destination }} email
@@ -96,6 +97,72 @@ describe Quartz::Message do
         message._{{ destination }}.first.tap do |email_address|
           email_address.addr.should eq email
           email_address.name.should eq name
+        end
+      end
+
+      {% remove_method = "remove_#{destination}_recipient".id %}
+
+      it "{{ remove_method }} allows removing destinations without name" do
+        message = build
+
+        message.{{ destination }} name: name, email: email
+        message.{{ destination }} name: name2, email: email2
+
+        message._{{ destination }}.size.should eq 2
+
+        message.{{ remove_method }} email
+        message._{{ destination }}.size.should eq 1
+        message._{{ destination }}.first.addr.should eq email2
+      end
+
+      it "{{ remove_method }} allows removing destinations with name" do
+        message = build
+
+        message.{{ destination }} name: name, email: email
+        message.{{ destination }} name: name2, email: email2
+
+        message._{{ destination }}.size.should eq 2
+
+        message.{{ remove_method }} name: name, email: email
+        message._{{ destination }}.size.should eq 1
+        message._{{ destination }}.first.addr.should eq email2
+        message._{{ destination }}.first.name.should eq name2
+      end
+
+      it "{{ remove_method }} allows removing destinations by array" do
+        message = build
+
+        message.{{ destination }} [address, address2]
+        message._{{ destination }}.size.should eq 2
+
+        message.{{ remove_method }} [address2]
+        message._{{ destination }}.size.should eq 1
+
+        message._{{ destination }}[0].tap do |email_address|
+          email_address.addr.should eq email
+          email_address.name.should eq name
+        end
+
+        message.{{ destination }} [address2]
+        message._{{ destination }}.size.should eq 2
+
+        message.{{ remove_method }} [address, address2]
+        message._{{ destination }}.size.should eq 0
+      end
+
+      it "{{ remove_method }} allows removing destination by named parameter" do
+        message = build
+
+        message.{{ destination }} name: name, email: email
+        message.{{ destination }} name: name2, email: email2
+        message._{{ destination }}.size.should eq 2
+
+        message.{{ remove_method }} name: name, email: email
+        message._{{ destination }}.size.should eq 1
+
+        message._{{ destination }}[0].tap do |email_address|
+          email_address.addr.should eq email2
+          email_address.name.should eq name2
         end
       end
     {% end %}

--- a/src/quartz_mailer/composer.cr
+++ b/src/quartz_mailer/composer.cr
@@ -6,7 +6,7 @@ class Quartz::Composer
 
   @message = Message.new
 
-  delegate :to, :subject, :text, :html, :body, to: @message
+  delegate :to, :subject, :text, :html, :body, :remove_to_recipient, :remove_cc_recipient, :remove_bcc_recipient, to: @message
   delegate :address, to: Message
 
   def deliver

--- a/src/quartz_mailer/message.cr
+++ b/src/quartz_mailer/message.cr
@@ -51,6 +51,28 @@ class Quartz::Message
         {{ destination_field }} address
       end
     end
+
+    {% remove_method = "remove_#{destination_field}_recipient".id %}
+
+    def {{ remove_method }}(*, email : String)
+      @_{{destination_field}}.reject!{|x| x.addr == email}
+    end
+
+    def {{ remove_method }}(email : String)
+      @_{{destination_field}}.reject!{|x| x.addr == email}
+    end
+
+    def {{ remove_method }}(name : String, email : String)
+      @_{{destination_field}}.reject!{|x| x.name == name && x.addr == email}
+    end
+
+    def {{ remove_method }}(address : Address)
+      @_{{destination_field}}.reject!{|x| x.name == address.name && x.addr == address.addr}
+    end
+
+    def {{ remove_method }}(addresses : Array(Address))
+      @_{{destination_field}}.reject!{|x| addresses.any?{|y| x.name == y.name && x.addr == y.addr}}
+    end
   {% end %}
 
   def subject(@_subject : String) : Nil


### PR DESCRIPTION
To remove a recipient:

```crystal
remove_to_recipient email: "to@foobar.com"
remove_cc_recipient email: "cc@foobar.com"
remove_bcc_recipient email: "bcc@foobar.com"
```

I wanted this feature because sometime I add recipients but then later want to scrub the list of any "Soft-deleted" users before sending the email.