### PR TITLE
Added support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies:
 require "quartz_mailer"
 ```
 
-The mailer has the ability to set the `from`, `to`, `cc`, `bcc`, and `subject` as well as both `text` and `html` body formats.
+The mailer has the ability to set the `from`, `to`, `cc`, `bcc`, and `subject` as well as both `text` and `html` body formats. You can also add cutom headers using `header` method.
 
 A `render` helper provides friendly markup rendering with [jeromegn/kilt](https://github.com/jeromegn/kilt).
 
@@ -33,6 +33,7 @@ class WelcomeMailer < Quartz::Composer
   def initialize(name : String, email : String)
     to name: name, email: email # Can be called multiple times to add more recipients
     subject "Welcome to Amber"
+    header "X-Custom-Header", "value" # Can be called multiple times to add more custom headers
     text render("mailers/welcome_mailer.text.ecr")
     html render("mailers/welcome_mailer.html.slang", "mailer-layout.html.slang")
   end
@@ -59,7 +60,7 @@ class MultipleRecipientMailer < Quartz::Composer
     address email: "info@amberframework.org", name: "Amber"
   end
 
-  def initialize(to_emails : Array(String), cc_emails = [] of String, bcc_emails = [] of String)
+  def initialize(to_emails : Array(String), cc_emails = [] of String, bcc_emails = [] of String, headers = [] of Hash(String, String))
     to_emails.each do |email|
       to email
     end
@@ -72,6 +73,10 @@ class MultipleRecipientMailer < Quartz::Composer
       bcc email
     end
 
+    headers.each do |name, value|
+      header name, value
+    end
+
     subject "Welcome to Amber"
     text render("mailers/welcome_mailer.text.ecr")
     html render("mailers/welcome_mailer.html.slang", "mailer-layout.html.slang")
@@ -80,7 +85,6 @@ end
 
 MultipleRecipientMailer.new(email_addrs, cc_email_addrs, bcc_email_addrs).deliver
 ```
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dependencies:
 require "quartz_mailer"
 ```
 
-The mailer has the ability to set the `from`, `to`, `cc`, `bcc`, and `subject` as well as both `text` and `html` body formats. You can also add cutom headers using `header` method.
+The mailer has the ability to set the `from`, `to`, `cc`, `bcc`, and `subject` as well as both `text` and `html` body formats. You can also add custom headers using `header` method.
 
 A `render` helper provides friendly markup rendering with [jeromegn/kilt](https://github.com/jeromegn/kilt).
 

--- a/spec/quartz/message_spec.cr
+++ b/spec/quartz/message_spec.cr
@@ -11,6 +11,7 @@ address2 = Quartz::Message.address name2, email2
 subject = "hello"
 text = "this is my email"
 html = "<h1>this is my email</h1>"
+header = ["X-Custom-Header", "Noice!"]
 
 def build
   Quartz::Message.new
@@ -195,6 +196,15 @@ describe Quartz::Message do
       message = build
       message.html html
       message._html.should eq html
+    end
+  end
+
+  context "custom header" do
+    it "allows setting a custom header" do
+      message = build
+      message.header header[0], header[1]
+      message._headers.size.should eq 1
+      message._headers["X-Custom-Header"].should eq "Noice!"
     end
   end
 

--- a/src/quartz_mailer/composer.cr
+++ b/src/quartz_mailer/composer.cr
@@ -6,7 +6,7 @@ class Quartz::Composer
 
   @message = Message.new
 
-  delegate :to, :cc, :bcc, :subject, :text, :html, :body, :remove_to_recipient, :remove_cc_recipient, :remove_bcc_recipient, to: @message
+  delegate :to, :cc, :bcc, :subject, :text, :html, :body, :header, :headers, :remove_to_recipient, :remove_cc_recipient, :remove_bcc_recipient, to: @message
   delegate :address, to: Message
 
   def deliver

--- a/src/quartz_mailer/message.cr
+++ b/src/quartz_mailer/message.cr
@@ -4,9 +4,10 @@ class Quartz::Message
   alias Address = EMail::Address
 
   getter _from : Address?
-  getter _to   = [] of Address
-  getter _cc   = [] of Address
-  getter _bcc  = [] of Address
+  getter _to = [] of Address
+  getter _cc = [] of Address
+  getter _bcc = [] of Address
+  getter _headers = {} of String => String
 
   getter _subject = ""
   getter _text = ""
@@ -31,7 +32,7 @@ class Quartz::Message
   def from(@_from : Address)
   end
 
-  {% for destination_field in [:to, :cc, :bcc] %}
+  {% for destination_field in [:to, :cc, :bcc, :header] %}
     {% destination_field = destination_field.id %}
 
     def {{ destination_field }}(email : String) : Nil
@@ -88,6 +89,10 @@ class Quartz::Message
   def body(@_text : String) : Nil
   end
 
+  def header(name : String, value : String) : Nil
+    @_headers[name] = value
+  end
+
   def to_email
     EMail::Message.new.tap do |email|
       email.subject @_subject
@@ -114,6 +119,10 @@ class Quartz::Message
 
       @_bcc.each do |person|
         email.bcc person
+      end
+
+      @_headers.each do |name, value|
+        email.custom_header name, value
       end
     end
   end


### PR DESCRIPTION
`crystal-email` supports custom headers. Added a `header` method to leverage that feature.