### PR TITLE
Custom headers example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class MultipleRecipientMailer < Quartz::Composer
     address email: "info@amberframework.org", name: "Amber"
   end
 
-  def initialize(to_emails : Array(String), cc_emails = [] of String, bcc_emails = [] of String, headers = [] of Hash(String, String))
+  def initialize(to_emails : Array(String), cc_emails = [] of String, bcc_emails = [] of String, headers = {} of String => String)
     to_emails.each do |email|
       to email
     end

--- a/src/quartz_mailer/message.cr
+++ b/src/quartz_mailer/message.cr
@@ -32,7 +32,7 @@ class Quartz::Message
   def from(@_from : Address)
   end
 
-  {% for destination_field in [:to, :cc, :bcc, :header] %}
+  {% for destination_field in [:to, :cc, :bcc] %}
     {% destination_field = destination_field.id %}
 
     def {{ destination_field }}(email : String) : Nil


### PR DESCRIPTION
Fixed example of custom headers in readme. Plus a left-over `:header` in the `destination_field`