### PR TITLE
Update crystal-email version from 0.3 to 0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.26.1
+FROM crystallang/crystal:0.33.0
 
 WORKDIR /app/user
 
@@ -9,4 +9,3 @@ RUN shards install
 ENV SMTP_URL localhost:25
 
 CMD ["crystal", "spec"]
-

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: quartz_mailer
 version: 0.5.3
 
-crystal: 0.24.1
+crystal: 0.33.0
 
 license: MIT
 
@@ -12,4 +12,4 @@ dependencies:
 
   email:
     github: arcage/crystal-email
-    version: ~> 0.3.0
+    version: ~> 0.4.0


### PR DESCRIPTION
### Description of the Change

Update `crystal-email` dependency from `0.3.X` to `0.4.X` in `shard.yml`

### Benefits

Make quartz-mailer reusable in Crystal 0.33 because `crystal-email` used `Time.now` which was **depreciated** in Crystal 0.32 and **removed** in Crystal 0.33 (they replaced `Time.now` by `Time.local` cf: https://github.com/arcage/crystal-email/releases/tag/v0.4.2)
