### PR TITLE
Bump kilt to latest version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ license: MIT
 dependencies:
   kilt:
     github: jeromegn/kilt
-    version: ~> 0.4.0
+    version: ~> 0.6.0
 
   email:
     github: arcage/crystal-email


### PR DESCRIPTION
Bumps kilt to the latest version (0.6.0) to add compatibility with jbuilder. 