### PR TITLE
Email smtps

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,5 +11,5 @@ dependencies:
     version: ~> 0.6.0
 
   email:
-    github: arcage/crystal-email
+    github: damianham/crystal-email
     version: ~> 0.4.0

--- a/shard.yml
+++ b/shard.yml
@@ -11,5 +11,5 @@ dependencies:
     version: ~> 0.6.0
 
   email:
-    github: damianham/crystal-email
-    version: ~> 0.4.0
+    github: arcage/crystal-email
+    version: ~> 0.6.0

--- a/spec/quartz/config_spec.cr
+++ b/spec/quartz/config_spec.cr
@@ -20,7 +20,7 @@ describe Quartz::Config do
 
     it "defaults to tls disabled" do
       Quartz.reset_config
-      Quartz.config.use_tls.should be_false
+      Quartz.config.use_tls.should eq EMail::Client::TLSMode::NONE
     end
 
     it "defaults to openssl_verify_mode default (:peer)" do
@@ -92,8 +92,8 @@ describe Quartz::Config do
       Quartz.config.smtp_port = mailcatcher_port
       Quartz.config.smtp_port.should eq mailcatcher_port
 
-      Quartz.config.use_tls = true
-      Quartz.config.use_tls.should eq true
+      Quartz.config.use_tls = EMail::Client::TLSMode::NONE
+      Quartz.config.use_tls.should eq EMail::Client::TLSMode::NONE
 
       Quartz.config.openssl_verify_mode = :none
       Quartz.config.openssl_verify_mode.should eq OpenSSL::SSL::VerifyMode::NONE

--- a/src/quartz_mailer.cr
+++ b/src/quartz_mailer.cr
@@ -16,6 +16,7 @@ class Quartz::Mailer
         config.smtp_port,
         use_tls: config.use_tls,
         logger: config.logger,
+        helo_domain: config.helo_domain,
         auth: {config.username, config.password},
         openssl_verify_mode: config.openssl_verify_mode
       )
@@ -24,6 +25,7 @@ class Quartz::Mailer
         message,
         config.smtp_address,
         config.smtp_port,
+        helo_domain: config.helo_domain,
         use_tls: config.use_tls,
         openssl_verify_mode: config.openssl_verify_mode,
         logger: config.logger,

--- a/src/quartz_mailer.cr
+++ b/src/quartz_mailer.cr
@@ -9,26 +9,31 @@ class Quartz::Mailer
       return
     end
 
+    unless config.helo_domain
+      config.logger.warn "HELO domain not configured, not sending email."
+      return
+    end
+
     if config.use_authentication
       connect_and_send(
         message,
         config.smtp_address,
         config.smtp_port,
         use_tls: config.use_tls,
-        logger: config.logger,
-        helo_domain: config.helo_domain,
+        #logger: config.logger,
+        helo_domain: config.helo_domain.not_nil!,
         auth: {config.username, config.password},
-        openssl_verify_mode: config.openssl_verify_mode
+        #openssl_verify_mode: config.openssl_verify_mode
       )
     else
       connect_and_send(
         message,
         config.smtp_address,
         config.smtp_port,
-        helo_domain: config.helo_domain,
+        helo_domain: config.helo_domain.not_nil!,
         use_tls: config.use_tls,
-        openssl_verify_mode: config.openssl_verify_mode,
-        logger: config.logger,
+        #openssl_verify_mode: config.openssl_verify_mode,
+        #logger: config.logger,
       )
     end
   end

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -5,7 +5,7 @@ module Quartz
 
     property! username : String?
     property! password : String?
-    property helo_domain : String? # = "domain_not_configured"
+    property helo_domain : String?
 
     property use_authentication = false
     property use_tls : EMail::Client::TLSMode = EMail::Client::TLSMode::NONE

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -5,10 +5,10 @@ module Quartz
 
     property! username : String?
     property! password : String?
-    property helo_domain : String?
+    property helo_domain : String? # = "domain_not_configured"
 
     property use_authentication = false
-    property use_tls = false
+    property use_tls : EMail::Client::TLSMode = EMail::Client::TLSMode::NONE
     property openssl_verify_mode : OpenSSL::SSL::VerifyMode = :peer
     property smtp_enabled = false
 

--- a/src/quartz_mailer/config.cr
+++ b/src/quartz_mailer/config.cr
@@ -5,6 +5,7 @@ module Quartz
 
     property! username : String?
     property! password : String?
+    property helo_domain : String?
 
     property use_authentication = false
     property use_tls = false


### PR DESCRIPTION
This is a temporary measure to enable quartz_mailer to work with release 0.6.0 of crystal-email to get around some compile errors.

crystal-email v0.6.0 uses the new Log class instead of the deprecated Logger class.